### PR TITLE
glide for vendor management

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ before_install:
     - glide install
 script:
   - test -z "$(gofmt -s -l . | tee /dev/stderr)"
-  - go test -v ./... -timeout 1m
+  - go test -timeout 1m -v $(glide novendor)
   - make build

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ notifications:
   email: false
 
 before_install:
-    - go get -d ./...
+    - go get -v github.com/Masterminds/glide
+    - glide install
 script:
   - test -z "$(gofmt -s -l . | tee /dev/stderr)"
   - go test -v ./... -timeout 1m

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,48 @@
+hash: c6f588ec3487a0e69f8b6e515036e33305cdcbdeb7dafe6d91dfc1a986923a18
+updated: 2017-06-20T07:53:19.183985911-04:00
+imports:
+- name: github.com/bitly/go-nsq
+  version: d71fb89c9e0263aaed89645b0b168e11ccf597b1
+- name: github.com/bsm/sarama-cluster
+  version: ccdc0803695fbce22f1706d04ded46cd518fd832
+- name: github.com/davecgh/go-spew
+  version: 346938d642f2ec3594ed81d874461961cd0faa76
+  subpackages:
+  - spew
+- name: github.com/eapache/go-resiliency
+  version: b1fe83b5b03f624450823b751b662259ffc6af70
+  subpackages:
+  - breaker
+- name: github.com/eapache/go-xerial-snappy
+  version: bb955e01b9346ac19dc29eb16586c90ded99a98c
+- name: github.com/eapache/queue
+  version: 44cc805cf13205b55f69e14bcb69867d1ae92f98
+- name: github.com/golang/snappy
+  version: 553a641470496b2327abcac10b36396bd98e45c9
+- name: github.com/kshvakov/clickhouse
+  version: 39dda5e9b892405ed3293b0234fbde2124704705
+- name: github.com/mreiferson/go-snappystream
+  version: 028eae7ab5c4c9e2d1cb4c4ca1e53259bbe7e504
+  subpackages:
+  - snappy-go
+- name: github.com/pierrec/lz4
+  version: 5a3d2245f97fc249850e7802e3c01fad02a1c316
+- name: github.com/pierrec/xxHash
+  version: 5a004441f897722c627870a981d02b29924215fa
+  subpackages:
+  - xxHash32
+- name: github.com/rcrowley/go-metrics
+  version: 1f30fe9094a513ce4c700b9a54458bbb0c96996c
+- name: github.com/Shopify/sarama
+  version: c01858abb625b73a3af51d0798e4ad42c8147093
+- name: golang.org/x/net
+  version: fe686d45ea04bc1bd4eff6a52865ce8757320325
+  subpackages:
+  - bpf
+  - internal/iana
+  - internal/socket
+  - ipv4
+  - ipv6
+- name: gopkg.in/yaml.v2
+  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,14 @@
+package: github.com/VerizonDigital/vflow
+import:
+- package: github.com/Shopify/sarama
+  version: ^1.12.0
+- package: github.com/bitly/go-nsq
+  version: ^1.0.6
+- package: github.com/bsm/sarama-cluster
+  version: ^2.1.8
+- package: github.com/kshvakov/clickhouse
+- package: golang.org/x/net
+  subpackages:
+  - ipv4
+  - ipv6
+- package: gopkg.in/yaml.v2


### PR DESCRIPTION
I have had nothing but issues with compiling go programs unless I do something to manage the vendor dependancies.   While currently [dep](https://github.com/golang/dep) is still being hammered into shape the community seams to have accepted [glide](https://github.com/Masterminds/glide) as the most common tool used.  

I have imported the glide.yaml and .locks that work for the versions I am using and tested with.  

Let me know if this is something this project would be willing to make use of. 
