### PR TITLE
fixing exported struct that needed comment

### DIFF
--- a/producer/nats.go
+++ b/producer/nats.go
@@ -37,6 +37,7 @@ type NATS struct {
 	logger     *log.Logger
 }
 
+// NATSConfig is the struct that holds all configuation for NATS connections
 type NATSConfig struct {
 	URL string `json:"endpoint"`
 }


### PR DESCRIPTION
As requested (correctly) in #13 add comment description for the NATSConfig structure. 