### PR TITLE
Make Mirror a unix only feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,16 +10,16 @@ test:
 bench:
 	go test -v ./... -bench=. -timeout 2m
 
-run:
-	cd vflow; go run $(GOFILES) -sflow-workers 100 -ipfix-workers 100
+run: build
+	cd vflow; ./vflow -sflow-workers 100 -ipfix-workers 100
 
-debug:
-	cd vflow; go run $(GOFILES) -sflow-workers 100 -ipfix-workers 100 -verbose=true
+debug: build
+	cd vflow; ./vflow -sflow-workers 100 -ipfix-workers 100 -verbose=true
 
-gctrace:
-	cd vflow; env GODEBUG=gctrace=1 go run $(GOFILES) -sflow-workers 100 -ipfix-workers 100
+gctrace: build
+	cd vflow; env GODEBUG=gctrace=1 ./vflow -sflow-workers 100 -ipfix-workers 100
 
-lint:	
+lint:
 	golint ./...
 
 cyclo:
@@ -37,4 +37,34 @@ depends:
 	go get -d ./...
 
 build: depends
-	cd vflow; go build $(LDFLAGS) -o vflow $(GOFILES)
+	cd vflow; go build $(LDFLAGS) 
+
+build-windows: depends
+	cd vflow; gox $(LDFLAGS) 
+
+
+vflow/vflow_windows_386.exe: depends
+	cd vflow; gox $(LDFLAGS) -os="windows" -arch="386"
+
+vflow/vflow_windows_amd64.exe: depends
+	cd vflow; gox $(LDFLAGS) -os="windows" -arch="amd64"
+
+vflow/vflow_darwin_386: depends
+	cd vflow; gox $(LDFLAGS) -os="darwin" -arch="386"
+
+vflow/vflow_darwin_amd64: depends
+	cd vflow; gox $(LDFLAGS) -os="darwin" -arch="amd64"
+
+vflow/vflow_freebsd_386: depends
+	cd vflow; gox $(LDFLAGS) -os="freebsd" -arch="386"
+
+vflow/vflow_freebsd_amd64: depends
+	cd vflow; gox $(LDFLAGS) -os="freebsd" -arch="amd64"
+
+vflow/vflow_linux_386: depends
+	cd vflow; gox $(LDFLAGS) -os="linux" -arch="386"
+
+vflow/vflow_linux_amd64: depends
+	cd vflow; gox $(LDFLAGS) -os="linux" -arch="amd64"
+
+cross-compile: vflow/vflow_windows_386.exe vflow/vflow_windows_amd64.exe vflow/vflow_darwin_386 vflow/vflow_darwin_amd64 vflow/vflow_freebsd_386 vflow/vflow_freebsd_amd64 vflow/vflow_linux_386 vflow/vflow_linux_amd64

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 PACKAGES=$(shell find . -name '*.go' -print0 | xargs -0 -n1 dirname | sort --unique)
-GOFILES= vflow.go ipfix.go sflow.go netflow_v9.go options.go stats.go 
 LDFLAGS= -ldflags "-X main.version=0.3.1"
 
 default: test
@@ -38,33 +37,3 @@ depends:
 
 build: depends
 	cd vflow; go build $(LDFLAGS) 
-
-build-windows: depends
-	cd vflow; gox $(LDFLAGS) 
-
-
-vflow/vflow_windows_386.exe: depends
-	cd vflow; gox $(LDFLAGS) -os="windows" -arch="386"
-
-vflow/vflow_windows_amd64.exe: depends
-	cd vflow; gox $(LDFLAGS) -os="windows" -arch="amd64"
-
-vflow/vflow_darwin_386: depends
-	cd vflow; gox $(LDFLAGS) -os="darwin" -arch="386"
-
-vflow/vflow_darwin_amd64: depends
-	cd vflow; gox $(LDFLAGS) -os="darwin" -arch="amd64"
-
-vflow/vflow_freebsd_386: depends
-	cd vflow; gox $(LDFLAGS) -os="freebsd" -arch="386"
-
-vflow/vflow_freebsd_amd64: depends
-	cd vflow; gox $(LDFLAGS) -os="freebsd" -arch="amd64"
-
-vflow/vflow_linux_386: depends
-	cd vflow; gox $(LDFLAGS) -os="linux" -arch="386"
-
-vflow/vflow_linux_amd64: depends
-	cd vflow; gox $(LDFLAGS) -os="linux" -arch="amd64"
-
-cross-compile: vflow/vflow_windows_386.exe vflow/vflow_windows_amd64.exe vflow/vflow_darwin_386 vflow/vflow_darwin_amd64 vflow/vflow_freebsd_386 vflow/vflow_freebsd_amd64 vflow/vflow_linux_386 vflow/vflow_linux_amd64

--- a/vflow/ipfix.go
+++ b/vflow/ipfix.go
@@ -31,7 +31,6 @@ import (
 	"time"
 
 	"github.com/VerizonDigital/vflow/ipfix"
-	"github.com/VerizonDigital/vflow/mirror"
 	"github.com/VerizonDigital/vflow/producer"
 )
 
@@ -259,99 +258,6 @@ func (i *IPFIX) status() *IPFIXStats {
 		DecodedCount:   atomic.LoadUint64(&i.stats.DecodedCount),
 		MQErrorCount:   atomic.LoadUint64(&i.stats.MQErrorCount),
 		Workers:        atomic.LoadInt32(&i.stats.Workers),
-	}
-}
-
-func mirrorIPFIX(dst net.IP, port int, ch chan IPFIXUDPMsg) error {
-	var (
-		packet = make([]byte, opts.IPFIXUDPSize)
-		msg    IPFIXUDPMsg
-		pLen   int
-		err    error
-		ipHdr  []byte
-		ipHLen int
-		ipv4   bool
-		ip     mirror.IP
-	)
-
-	conn, err := mirror.NewRawConn(dst)
-	if err != nil {
-		return err
-	}
-
-	udp := mirror.UDP{55117, port, 0, 0}
-	udpHdr := udp.Marshal()
-
-	if dst.To4() != nil {
-		ipv4 = true
-	}
-
-	if ipv4 {
-		ip = mirror.NewIPv4HeaderTpl(mirror.UDPProto)
-		ipHdr = ip.Marshal()
-		ipHLen = mirror.IPv4HLen
-	} else {
-		ip = mirror.NewIPv6HeaderTpl(mirror.UDPProto)
-		ipHdr = ip.Marshal()
-		ipHLen = mirror.IPv6HLen
-	}
-
-	for {
-		msg = <-ch
-		pLen = len(msg.body)
-
-		ip.SetAddrs(ipHdr, msg.raddr.IP, dst)
-		ip.SetLen(ipHdr, pLen+mirror.UDPHLen)
-
-		udp.SetLen(udpHdr, pLen)
-		// IPv6 checksum mandatory
-		if !ipv4 {
-			udp.SetChecksum()
-		}
-
-		copy(packet[0:ipHLen], ipHdr)
-		copy(packet[ipHLen:ipHLen+8], udpHdr)
-		copy(packet[ipHLen+8:], msg.body)
-
-		ipfixBuffer.Put(msg.body[:opts.IPFIXUDPSize])
-
-		if err = conn.Send(packet[0 : ipHLen+8+pLen]); err != nil {
-			return err
-		}
-	}
-}
-
-func mirrorIPFIXDispatcher(ch chan IPFIXUDPMsg) {
-	var (
-		ch4 = make(chan IPFIXUDPMsg, 1000)
-		ch6 = make(chan IPFIXUDPMsg, 1000)
-		msg IPFIXUDPMsg
-	)
-
-	if opts.IPFIXMirrorAddr == "" {
-		return
-	}
-
-	for w := 0; w < opts.IPFIXMirrorWorkers; w++ {
-		dst := net.ParseIP(opts.IPFIXMirrorAddr)
-
-		if dst.To4() != nil {
-			go mirrorIPFIX(dst, opts.IPFIXMirrorPort, ch4)
-		} else {
-			go mirrorIPFIX(dst, opts.IPFIXMirrorPort, ch6)
-		}
-	}
-
-	ipfixMirrorEnabled = true
-	logger.Printf("ipfix mirror service is running (workers#: %d) ...", opts.IPFIXMirrorWorkers)
-
-	for {
-		msg = <-ch
-		if msg.raddr.IP.To4() != nil {
-			ch4 <- msg
-		} else {
-			ch6 <- msg
-		}
 	}
 }
 

--- a/vflow/ipfix_unix.go
+++ b/vflow/ipfix_unix.go
@@ -1,0 +1,122 @@
+//: ----------------------------------------------------------------------------
+//: Copyright (C) 2017 Verizon.  All Rights Reserved.
+//: All Rights Reserved
+//:
+//: file:    ipfix.go
+//: author:  Mehrdad Arshad Rad - copied by Jeremy Rossi, but not important
+//: date:    02/01/2017
+//:
+//: Licensed under the Apache License, Version 2.0 (the "License");
+//: you may not use this file except in compliance with the License.
+//: You may obtain a copy of the License at
+//:
+//:     http://www.apache.org/licenses/LICENSE-2.0
+//:
+//: Unless required by applicable law or agreed to in writing, software
+//: distributed under the License is distributed on an "AS IS" BASIS,
+//: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//: See the License for the specific language governing permissions and
+//: limitations under the License.
+//: ----------------------------------------------------------------------------
+// +build !windows
+
+package main
+
+import (
+	"github.com/VerizonDigital/vflow/mirror"
+
+	"net"
+)
+
+func mirrorIPFIXDispatcher(ch chan IPFIXUDPMsg) {
+	var (
+		ch4 = make(chan IPFIXUDPMsg, 1000)
+		ch6 = make(chan IPFIXUDPMsg, 1000)
+		msg IPFIXUDPMsg
+	)
+
+	if opts.IPFIXMirrorAddr == "" {
+		return
+	}
+
+	for w := 0; w < opts.IPFIXMirrorWorkers; w++ {
+		dst := net.ParseIP(opts.IPFIXMirrorAddr)
+
+		if dst.To4() != nil {
+			go mirrorIPFIX(dst, opts.IPFIXMirrorPort, ch4)
+		} else {
+			go mirrorIPFIX(dst, opts.IPFIXMirrorPort, ch6)
+		}
+	}
+
+	ipfixMirrorEnabled = true
+	logger.Printf("ipfix mirror service is running (workers#: %d) ...", opts.IPFIXMirrorWorkers)
+
+	for {
+		msg = <-ch
+		if msg.raddr.IP.To4() != nil {
+			ch4 <- msg
+		} else {
+			ch6 <- msg
+		}
+	}
+}
+
+func mirrorIPFIX(dst net.IP, port int, ch chan IPFIXUDPMsg) error {
+	var (
+		packet = make([]byte, opts.IPFIXUDPSize)
+		msg    IPFIXUDPMsg
+		pLen   int
+		err    error
+		ipHdr  []byte
+		ipHLen int
+		ipv4   bool
+		ip     mirror.IP
+	)
+
+	conn, err := mirror.NewRawConn(dst)
+	if err != nil {
+		return err
+	}
+
+	udp := mirror.UDP{55117, port, 0, 0}
+	udpHdr := udp.Marshal()
+
+	if dst.To4() != nil {
+		ipv4 = true
+	}
+
+	if ipv4 {
+		ip = mirror.NewIPv4HeaderTpl(mirror.UDPProto)
+		ipHdr = ip.Marshal()
+		ipHLen = mirror.IPv4HLen
+	} else {
+		ip = mirror.NewIPv6HeaderTpl(mirror.UDPProto)
+		ipHdr = ip.Marshal()
+		ipHLen = mirror.IPv6HLen
+	}
+
+	for {
+		msg = <-ch
+		pLen = len(msg.body)
+
+		ip.SetAddrs(ipHdr, msg.raddr.IP, dst)
+		ip.SetLen(ipHdr, pLen+mirror.UDPHLen)
+
+		udp.SetLen(udpHdr, pLen)
+		// IPv6 checksum mandatory
+		if !ipv4 {
+			udp.SetChecksum()
+		}
+
+		copy(packet[0:ipHLen], ipHdr)
+		copy(packet[ipHLen:ipHLen+8], udpHdr)
+		copy(packet[ipHLen+8:], msg.body)
+
+		ipfixBuffer.Put(msg.body[:opts.IPFIXUDPSize])
+
+		if err = conn.Send(packet[0 : ipHLen+8+pLen]); err != nil {
+			return err
+		}
+	}
+}

--- a/vflow/ipfix_windows.go
+++ b/vflow/ipfix_windows.go
@@ -1,0 +1,26 @@
+//: ----------------------------------------------------------------------------
+//: Copyright (C) 2017 Verizon.  All Rights Reserved.
+//: All Rights Reserved
+//:
+//: file:    ipfix.go
+//: author:  Mehrdad Arshad Rad - copied by Jeremy Rossi, but not important
+//: date:    02/01/2017
+//:
+//: Licensed under the Apache License, Version 2.0 (the "License");
+//: you may not use this file except in compliance with the License.
+//: You may obtain a copy of the License at
+//:
+//:     http://www.apache.org/licenses/LICENSE-2.0
+//:
+//: Unless required by applicable law or agreed to in writing, software
+//: distributed under the License is distributed on an "AS IS" BASIS,
+//: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//: See the License for the specific language governing permissions and
+//: limitations under the License.
+//: ----------------------------------------------------------------------------
+
+package main
+
+func mirrorIPFIXDispatcher(ch chan IPFIXUDPMsg) {
+	return
+}

--- a/vflow/ipfix_windows.go
+++ b/vflow/ipfix_windows.go
@@ -18,6 +18,7 @@
 //: See the License for the specific language governing permissions and
 //: limitations under the License.
 //: ----------------------------------------------------------------------------
+// +build windows
 
 package main
 


### PR DESCRIPTION
This should correct #11 as mirror is not something that is going to work on windows at the least with the method currently used.  

This patch is not prefect in anyway due the way that configuration is implement in vflow.  I more then happy for work on something a little easier to support, but will start that chat in another issues. 

