### PR TITLE
fix ethernet packet format

### DIFF
--- a/packet/ethernet.go
+++ b/packet/ethernet.go
@@ -108,8 +108,8 @@ func decodeIEEE802(b []byte) (Datalink, error) {
 	hwAddrFmt := "%0.2x:%0.2x:%0.2x:%0.2x:%0.2x:%0.2x"
 
 	if d.EtherType != EtherTypeIEEE8021Q {
-		d.SrcMAC = fmt.Sprintf(hwAddrFmt, b[0], b[1], b[2], b[3], b[4], b[5])
-		d.DstMAC = fmt.Sprintf(hwAddrFmt, b[6], b[7], b[8], b[9], b[10], b[11])
+		d.DstMAC = fmt.Sprintf(hwAddrFmt, b[0], b[1], b[2], b[3], b[4], b[5])
+		d.SrcMAC = fmt.Sprintf(hwAddrFmt, b[6], b[7], b[8], b[9], b[10], b[11])
 	}
 
 	return d, nil

--- a/packet/ethernet_test.go
+++ b/packet/ethernet_test.go
@@ -37,11 +37,11 @@ func TestDecodeIEEE802(t *testing.T) {
 		t.Error("unexpected error", err)
 	}
 
-	if d.SrcMAC != "d4:04:ff:01:1d:9e" {
+	if d.DstMAC != "d4:04:ff:01:1d:9e" {
 		t.Error("expected d4:04:ff:01:1d:9e, got", d.SrcMAC)
 	}
 
-	if d.DstMAC != "30:7c:5e:e5:59:ef" {
+	if d.SrcMAC != "30:7c:5e:e5:59:ef" {
 		t.Error("expected 30:7c:5e:e5:59:ef, got", d.DstMAC)
 	}
 


### PR DESCRIPTION
The order of DstMAC and SrcMAC is reversed.