### PR TITLE
Added custom vmware parameter support

### DIFF
--- a/ipfix/decoder.go
+++ b/ipfix/decoder.go
@@ -489,8 +489,8 @@ func (d *Decoder) decodeData(tr TemplateRecord) ([]DecodedField, error) {
 		}]
 
 		if !ok {
-			return nil, nonfatalError(fmt.Errorf("IPFIX element key (%d) not exist",
-				tr.FieldSpecifiers[i].ElementID))
+			return nil, nonfatalError(fmt.Errorf("IPFIX element key: ID (%d), EnterpriseNo (%d) does not exist",
+				tr.FieldSpecifiers[i].ElementID,tr.FieldSpecifiers[i].EnterpriseNo))
 		}
 
 		fields = append(fields, DecodedField{

--- a/ipfix/rfc5102_model.go
+++ b/ipfix/rfc5102_model.go
@@ -4,6 +4,7 @@
 //:
 //: file:    ipfix.go
 //: details: IP Flow Information Export (IPFIX) entities model - https://www.iana.org/assignments/ipfix/ipfix.xhtml
+//:          VMware Custom Parameters - https://docs.vmware.com/en/VMware-NSX-for-vSphere/6.4/com.vmware.nsx.admin.doc/GUID-40805D0E-8A97-4011-B85C-CBF37812DBB5.html
 //: author:  Mehrdad Arshad Rad
 //: date:    02/01/2017
 //:
@@ -550,4 +551,10 @@ var InfoModel = IANAInfoModel{
 	ElementKey{0, 431}: InfoElementEntry{FieldID: 431, Name: "layer2FrameTotalCount", Type: FieldTypes["unsigned64"]},
 	ElementKey{0, 432}: InfoElementEntry{FieldID: 432, Name: "pseudoWireDestinationIPv4Address", Type: FieldTypes["ipv4Address"]},
 	ElementKey{0, 433}: InfoElementEntry{FieldID: 433, Name: "ignoredLayer2FrameTotalCount", Type: FieldTypes["unsigned64"]},
+	//vmWare elements 
+        ElementKey{6876, 210}: InfoElementEntry{FieldID: 210, Name: "paddingOctets", Type: FieldTypes["octetArray"]},
+        ElementKey{6876, 888}: InfoElementEntry{FieldID: 888, Name: "egressInterfaceAttr", Type: FieldTypes["unsigned16"]},
+        ElementKey{6876, 889}: InfoElementEntry{FieldID: 889, Name: "vxlanExportRole", Type: FieldTypes["unsigned8"]},
+        ElementKey{6876, 890}: InfoElementEntry{FieldID: 890, Name: "ingressInterfaceAttr", Type: FieldTypes["unsigned16"]},
+
 }

--- a/ipfix/rfc5102_model.go
+++ b/ipfix/rfc5102_model.go
@@ -551,10 +551,9 @@ var InfoModel = IANAInfoModel{
 	ElementKey{0, 431}: InfoElementEntry{FieldID: 431, Name: "layer2FrameTotalCount", Type: FieldTypes["unsigned64"]},
 	ElementKey{0, 432}: InfoElementEntry{FieldID: 432, Name: "pseudoWireDestinationIPv4Address", Type: FieldTypes["ipv4Address"]},
 	ElementKey{0, 433}: InfoElementEntry{FieldID: 433, Name: "ignoredLayer2FrameTotalCount", Type: FieldTypes["unsigned64"]},
-	//vmWare elements 
-        ElementKey{6876, 210}: InfoElementEntry{FieldID: 210, Name: "paddingOctets", Type: FieldTypes["octetArray"]},
-        ElementKey{6876, 888}: InfoElementEntry{FieldID: 888, Name: "egressInterfaceAttr", Type: FieldTypes["unsigned16"]},
-        ElementKey{6876, 889}: InfoElementEntry{FieldID: 889, Name: "vxlanExportRole", Type: FieldTypes["unsigned8"]},
-        ElementKey{6876, 890}: InfoElementEntry{FieldID: 890, Name: "ingressInterfaceAttr", Type: FieldTypes["unsigned16"]},
-
+	//VMware elements
+	ElementKey{6876, 210}: InfoElementEntry{FieldID: 210, Name: "paddingOctets", Type: FieldTypes["octetArray"]},
+	ElementKey{6876, 888}: InfoElementEntry{FieldID: 888, Name: "egressInterfaceAttr", Type: FieldTypes["unsigned16"]},
+	ElementKey{6876, 889}: InfoElementEntry{FieldID: 889, Name: "vxlanExportRole", Type: FieldTypes["unsigned8"]},
+	ElementKey{6876, 890}: InfoElementEntry{FieldID: 890, Name: "ingressInterfaceAttr", Type: FieldTypes["unsigned16"]},
 }

--- a/vflow/ipfix.go
+++ b/vflow/ipfix.go
@@ -30,7 +30,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/VerizonDigital/vflow/ipfix"
+	"github.com/tomasflorian/vflow/ipfix"
 	"github.com/VerizonDigital/vflow/producer"
 )
 


### PR DESCRIPTION
Hi Guys,

This is my first pull request so excuse me if I'm doing this wrong.   I'm using vflow with vcenter 6.5 and I ran into a compatibility problem because vcenter injects it's own custom elements into IPFIX.   I fixed the problem by augmenting rfc5102_model with the required parameters (4 for now just to avoid errors in my particular system).   If this pull is accepted, I would like to add the rest as per

https://docs.vmware.com/en/VMware-NSX-for-vSphere/6.4/com.vmware.nsx.admin.doc/GUID-40805D0E-8A97-4011-B85C-CBF37812DBB5.html

Thanks,
Tomas