### PR TITLE
Swap sarama for segmentio kafka library

### DIFF
--- a/producer/kafka.go
+++ b/producer/kafka.go
@@ -53,12 +53,12 @@ type Kafka struct {
 type Config struct {
 	run             kafka.WriterConfig
 	Brokers         []string `yaml:"brokers" env:"BROKERS"`
-	BootstrapServer string   `yaml:"bootstrap_server" env:"BOOTSTRAP_SERVER"`
-	ClientID        string   `yaml:"client_id" env:"CLIENT_ID"`
+	BootstrapServer string   `yaml:"bootstrap-server" env:"BOOTSTRAP_SERVER"`
+	ClientID        string   `yaml:"client-id" env:"CLIENT_ID"`
 	Compression     string   `yaml:"compression" env:"COMPRESSION"`
-	MaxAttempts     int      `yaml:"max_attempts" env:"MAX_ATTEMPTS"`
-	QueueSize       int      `yaml:"queue_size" env:"QUEUE_SIZE"`
-	BatchSize       int      `yaml:"batch_size" env:"BATCH_SIZE"`
+	MaxAttempts     int      `yaml:"max-attempts" env:"MAX_ATTEMPTS"`
+	QueueSize       int      `yaml:"queue-size" env:"QUEUE_SIZE"`
+	BatchSize       int      `yaml:"batch-size" env:"BATCH_SIZE"`
 	Keepalive       int      `yaml:"keepalive" env:"KEEPALIVE"`
 	IOTimeout       int      `yaml:"connect-timeout" env:"CONNECT_TIMEOUT"`
 	RequiredAcks    int      `yaml:"required-acks" env:"REQUIRED_ACKS"`

--- a/producer/kafka.go
+++ b/producer/kafka.go
@@ -105,8 +105,6 @@ func (k *Kafka) setup(configFile string, logger *log.Logger) error {
 		}
 	}
 
-	k.logger.Printf("using kafka brokers %v", k.config.Brokers)
-
 	// init kafka configuration
 	k.config.run = kafka.WriterConfig{
 		Brokers: k.config.Brokers,


### PR DESCRIPTION
The kafka library from segmentio provides the same kafka connectivity capability in a smaller package size. According to the authors it should also use less memory. Also included is functionality to support the use of a bootstrap server ( a dns record that points to available brokers ).