### PR TITLE
Bumps golang image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build vFlow in the first stage
-FROM golang:1.8.3 as builder
+FROM golang:1.11.4 as builder
 
 WORKDIR /go/src/
 


### PR DESCRIPTION
While building the Docker image with the original "golang:1.8.3" the build fails with:
```
../../../nats-io/nkeys/strkey.go:54: base32.StdEncoding.WithPadding undefined (type *base32.Encoding has no field or method WithPadding)
../../../nats-io/nkeys/strkey.go:54: undefined: base32.NoPadding
```
Bumping the golang version fixes the issue.

I'm building the docker image on:
macOS 10.14.2 (18C54)
docker (client) version: 18.09