### PR TITLE
SourceID should be uint32

### DIFF
--- a/sflow/flow_sample.go
+++ b/sflow/flow_sample.go
@@ -93,8 +93,6 @@ func (fs *FlowSample) unmarshal(r io.ReadSeeker) error {
 		return err
 	}
 
-	r.Seek(3, 1) // skip counter sample decoding
-
 	if err = read(r, &fs.SamplingRate); err != nil {
 		return err
 	}


### PR DESCRIPTION
According to https://sflow.org/SFLOW-DATAGRAM5.txt the SourceID should be treated as uint32.
The current implementation only allows decoding of one byte instead of the whole data in source_id.

```
/* sFlowDataSource encoded as follows:
     The most significant byte of the source_id is used to indicate the type
     of sFlowDataSource:
        0 = ifIndex
        1 = smonVlanDataSource
        2 = entPhysicalEntry
     The lower three bytes contain the relevant index value. */

typedef unsigned int sflow_data_source;
```

```
struct flow_sample {
   unsigned int sequence_number;  /* Incremented with each flow sample
                                     generated by this source_id.
                                     Note: If the agent resets the
                                           sample_pool then it must
                                           also reset the sequence_number.*/
   sflow_data_source source_id;   /* sFlowDataSource */
   unsigned int sampling_rate;    /* sFlowPacketSamplingRate */
   unsigned int sample_pool;      /* Total number of packets that could have
                                     been sampled (i.e. packets skipped by
                                     sampling process + total number of
                                     samples) */
   unsigned int drops;            /* Number of times that the sFlow agent
                                     detected that a packet marked to be 
                                     sampled was dropped due to
                                     lack of resources. The drops counter
                                     reports the total number of drops
                                     detected since the agent was last reset.
                                     A high drop rate indicates that the 
                                     management agent is unable to process 
                                     samples as fast as they are being 
                                     generated by hardware. Increasing 
                                     sampling_rate will reduce the drop 
                                     rate. Note: An agent that cannot 
                                     detect drops will always report
                                     zero. */

   interface input;               /* Interface packet was received on. */
   interface output;              /* Interface packet was sent on. */

   flow_record flow_records<>;    /* Information about a sampled packet */
}
```